### PR TITLE
chore: bump package version to 1.0.0

### DIFF
--- a/apppop-bootstrap/package.json
+++ b/apppop-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apppop/bootstrap",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Project bootstrapping tool for AppPop applications",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Incremented package version for @apppop/bootstrap to 1.0.0, indicating a major version release